### PR TITLE
small_table.py: Replace deprecated from_csv function

### DIFF
--- a/scripts/small_table.py
+++ b/scripts/small_table.py
@@ -1,3 +1,3 @@
 import pandas as pd
-df = pd.DataFrame.from_csv("data/sucrosepreference.csv")
+df = pd.read_csv("data/sucrosepreference.csv")
 print(df.to_latex())


### PR DESCRIPTION
The `pandas.Datafiles.from_csv()` function has been deprecated. Upstream recommend using `pandas.read_csv()`. 